### PR TITLE
Configure GitHub action for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish MCP Server
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Setup Node.js and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          registry-url: "https://registry.npmjs.org"
+
+      # Verification steps
+      - name: Check if NPM_TOKEN secret exists
+        run: |
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "❌ NPM_TOKEN secret is not set"
+            exit 1
+          else
+            echo "✅ NPM_TOKEN secret exists"
+          fi
+
+      - name: Verify NPM authentication
+        run: npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Check package.json exists
+        run: |
+          if [ ! -f "package.json" ]; then
+            echo "❌ package.json not found"
+            exit 1
+          else
+            echo "✅ package.json found"
+            cat package.json | grep -E '"name"|"version"'
+          fi
+
+      - name: Publish to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,21 @@
 {
   "name": "anki-mcp",
+  "version": "1.0.0",
+  "description": "A Model Context Protocol (MCP) server for Anki",
+  "main": "index.ts",
   "module": "index.ts",
   "type": "module",
+  "keywords": ["mcp", "model-context-protocol", "anki", "server"],
+  "author": "",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/YOUR_USERNAME/anki-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/YOUR_USERNAME/anki-mcp/issues"
+  },
+  "homepage": "https://github.com/YOUR_USERNAME/anki-mcp#readme",
   "scripts": {
     "inspector": "npx @modelcontextprotocol/inspector bun run index.ts"
   },


### PR DESCRIPTION
Configure GitHub Action for NPM publishing and update `package.json` for release readiness.

The workflow was adapted from a monorepo assumption to a single-package structure, removing an unnecessary build step and adjusting paths. `package.json` was updated with essential fields (version, description, repository, etc.) required for NPM publishing.