### PR TITLE
feat: adding in search over decks

### DIFF
--- a/lib/handlers.ts
+++ b/lib/handlers.ts
@@ -1,4 +1,5 @@
 import { YankiConnect } from "yanki-connect";
+import { getStatus } from "./helper";
 
 export const listAnkiDecks = async () => {
   const client = new YankiConnect();
@@ -49,24 +50,21 @@ export const getCardsInDeckHandler = async ({
     // Get card info for each ID
     const cardsInfo = await client.card.cardsInfo({ cards: paginatedIds });
 
-    const formattedCards = cardsInfo.map((card) => ({
-      id: card.cardId,
-      front:
-        card.fields?.Front?.value ||
-        card.fields?.Question?.value ||
-        "No front field",
-      back:
-        card.fields?.Back?.value ||
-        card.fields?.Answer?.value ||
-        "No back field",
-      deckName: card.deckName,
-      modelName: card.modelName,
-      due: card.due,
-      interval: card.interval,
-      intervalString: card.interval === 1 ? "1 day" : `every ${card.interval} days`,
-      reviews: card.reps,
-      lapses: card.lapses,
-    }));
+    const formattedCards = cardsInfo.map((card) => {
+      return {
+        id: card.cardId,
+        front:
+          card.fields?.Front?.value ||
+          card.fields?.Question?.value ||
+          "No front field",
+        back:
+          card.fields?.Back?.value ||
+          card.fields?.Answer?.value ||
+          "No back field",
+        state: getStatus(card),
+        deckName: card.deckName,
+      };
+    });
 
     return {
       content: [
@@ -118,34 +116,67 @@ export const searchCardsHandler = async ({
 }: {
   query: string;
   deckName?: string;
-}) => ({
-  content: [
-    {
-      type: "text" as const,
-      text: JSON.stringify(
-        [
+}) => {
+  const client = new YankiConnect();
+
+  try {
+    // Build the search query
+    let searchQuery = query;
+    if (deckName) {
+      searchQuery = `deck:"${deckName}" (${query})`;
+    }
+
+    const cardIds = await client.card.findCards({ query: searchQuery });
+
+    if (cardIds.length === 0) {
+      return {
+        content: [
           {
-            id: 1,
-            front: "こんにちは",
-            back: "Hello",
-            state: "review",
-            deckName: "Japanese",
+            type: "text" as const,
+            text: JSON.stringify([]),
           },
-          {
-            id: 5,
-            front: "Hello world",
-            back: "A common first program",
-            state: "new",
-            deckName: "Computer Science",
-          },
-        ]
-          .filter(
-            (card) =>
-              card.front.toLowerCase().includes(query.toLowerCase()) ||
-              card.back.toLowerCase().includes(query.toLowerCase())
-          )
-          .filter((card) => !deckName || card.deckName === deckName)
-      ),
-    },
-  ],
-});
+        ],
+      };
+    }
+
+    // Get card info for each ID
+    const cardsInfo = await client.card.cardsInfo({ cards: cardIds });
+
+    const formattedCards = cardsInfo.map((card) => {
+      return {
+        id: card.cardId,
+        front:
+          card.fields?.Front?.value ||
+          card.fields?.Question?.value ||
+          "No front field",
+        back:
+          card.fields?.Back?.value ||
+          card.fields?.Answer?.value ||
+          "No back field",
+        state: getStatus(card),
+        deckName: card.deckName,
+      };
+    });
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify(formattedCards),
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            error: "Failed to search cards",
+            message: error instanceof Error ? error.message : "Unknown error",
+          }),
+        },
+      ],
+    };
+  }
+};

--- a/lib/helper.ts
+++ b/lib/helper.ts
@@ -1,0 +1,16 @@
+export const getStatus = (card: any): string => {
+  switch (card.queue) {
+    case -1:
+      return "suspended";
+    case 0:
+      return "new";
+    case 1:
+      return "learning";
+    case 2:
+      return "review";
+    default:
+      return "unknown";
+  }
+};
+
+


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR
Implemented live search for Anki cards within decks, replacing mock data with real-time `YankiConnect` integration and enhancing card status display.

## Why we made these changes
To enable real-time, accurate search functionality for Anki cards, improving user experience by moving from static mock data to live data. Supports the new "search over decks" feature.

## What changed?
- `lib/handlers.ts`: `searchCardsHandler` refactored for live Anki searches via `YankiConnect`. `getCardsInDeckHandler` updated to return simplified card objects with a new `state` field.
- `lib/helper.ts`: New file, `getStatus` function added to map Anki card queue values to descriptive statuses (e.g., "new", "learning").

## Validation
- Live search returns correct results from Anki.
- Card statuses (new, learning, review, suspended) display accurately.
- `getCardsInDeckHandler` provides simplified card objects as expected.
<!-- mesa-description-end -->